### PR TITLE
Fix auth initialization hang by resolving before profile load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,7 +93,7 @@ const InitializationError = ({ error }: { error: string }) => (
 
 // Auth Guard Component with better error handling
 const AuthGuard = ({ children }: { children: React.ReactNode }) => {
-  const { user, isInitialized, error } = useAuthStore();
+  const { user, firebaseUser, isInitialized, error } = useAuthStore();
   const [authTimeout, setAuthTimeout] = useState(false);
 
   useEffect(() => {
@@ -124,6 +124,12 @@ const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   // Show error if there's a critical auth error
   if (error && error.includes('critical')) {
     return <InitializationError error={error} />;
+  }
+
+  // If Firebase has authenticated the user but we're still loading the profile data,
+  // keep the guard in a loading state so we don't incorrectly redirect to login.
+  if (firebaseUser && !user && !error) {
+    return <LoadingSpinner message="Loading your profile..." />;
   }
 
   // Redirect to login if not authenticated


### PR DESCRIPTION
## Summary
- resolve the authentication initialization promise as soon as Firebase reports a user state to avoid app-level timeouts
- keep the auth guard in a loading state while the Firebase user is known but the profile data is still loading to prevent premature redirects

## Testing
- npm run lint *(fails: repository has pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c566bc80832699e03cd9f532f7f6